### PR TITLE
Change JYTHON to jython-standalone to avoid error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         </dependency>
         <dependency>
             <groupId>org.python</groupId>
-            <artifactId>jython-slim</artifactId>
+            <artifactId>jython-standalone</artifactId>
             <version>2.7.2</version>
             <scope>compile</scope>
         </dependency>


### PR DESCRIPTION
slim jython may curse error when plugin loaded, replace to jython-standalone to avoid this error