### PR TITLE
Fix directories not being created on first run

### DIFF
--- a/src/main/java/dev/magicmq/pyspigot/PySpigot.java
+++ b/src/main/java/dev/magicmq/pyspigot/PySpigot.java
@@ -219,7 +219,7 @@ public class PySpigot extends JavaPlugin {
         for (String folder : folders) {
             File file = new File(getDataFolder(), folder);
             if (!file.exists())
-                file.mkdir();
+                file.mkdirs();
         }
     }
 


### PR DESCRIPTION
`mkdir()` will not create directories that do not have their parent directory already created. We run into this issue because the plugin's data folder isn't created by the plugin by default so instead we use `mkdirs()` which also creates parent directories. The plugin folder does get initialized by plugin's configs when they get loaded however we probably should avoid relying on that so we aren't depending on load order of something else that doesn't explicitly create the parent directory.

Initial directory structure for both tests
![O3nnU88AQP](https://github.com/magicmq/pyspigot/assets/11567285/e1efc1e7-f08f-4177-a7be-712b82f72bcd)
PySpigot directory after first run before fix
![oBtQgkMeHV](https://github.com/magicmq/pyspigot/assets/11567285/385085c4-2fe9-4c43-8fe4-5d48669235f1)
PySpigot directory after first run after fix
![HvUkVYuCkv](https://github.com/magicmq/pyspigot/assets/11567285/5cf73d2e-368d-4a80-be53-dc3adcd5872b)
