### PR TITLE
Rework ReflectionUtil versioning

### DIFF
--- a/src/main/java/dev/magicmq/pyspigot/util/ReflectionUtils.java
+++ b/src/main/java/dev/magicmq/pyspigot/util/ReflectionUtils.java
@@ -17,8 +17,10 @@
 package dev.magicmq.pyspigot.util;
 
 import org.bukkit.Bukkit;
+import org.bukkit.Server;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 /**
@@ -29,7 +31,16 @@ public final class ReflectionUtils {
     private static final String MC_VERSION;
 
     static {
-        MC_VERSION = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
+        Server server = Bukkit.getServer();
+        Class<?> serverClass = server.getClass();
+        Method getMinecraftVersion = getMethod(serverClass, "getMinecraftVersion");
+        try {
+            MC_VERSION = getMinecraftVersion != null ?
+                    (String) getMinecraftVersion.invoke(server) :
+                    serverClass.getPackage().getName().split("\\.")[3];
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private ReflectionUtils() {}
@@ -43,11 +54,19 @@ public final class ReflectionUtils {
     }
 
     public static Class<?> getCraftBukkitClass(String className) throws ClassNotFoundException {
-        return Class.forName("org.bukkit.craftbukkit." + MC_VERSION + "." + className);
+        try {
+            return Class.forName("org.bukkit.craftbukkit." + className);
+        } catch (ClassNotFoundException ignored) {
+            return Class.forName("org.bukkit.craftbukkit." + MC_VERSION + "." + className);
+        }
     }
 
     public static Class<?> getCraftBukkitClass(String packageName, String className) throws ClassNotFoundException {
-        return Class.forName("org.bukkit.craftbukkit." + MC_VERSION + "." + packageName + "." + className);
+        try {
+            return Class.forName("org.bukkit.craftbukkit." + packageName + "." + className);
+        } catch (ClassNotFoundException ignored) {
+            return Class.forName("org.bukkit.craftbukkit." + MC_VERSION + "." + packageName + "." + className);
+        }
     }
 
     public static Method getMethod(Class<?> clazz, String methodName) {

--- a/src/main/java/dev/magicmq/pyspigot/util/ReflectionUtils.java
+++ b/src/main/java/dev/magicmq/pyspigot/util/ReflectionUtils.java
@@ -31,16 +31,8 @@ public final class ReflectionUtils {
     private static final String MC_VERSION;
 
     static {
-        Server server = Bukkit.getServer();
-        Class<?> serverClass = server.getClass();
-        Method getMinecraftVersion = getMethod(serverClass, "getMinecraftVersion");
-        try {
-            MC_VERSION = getMinecraftVersion != null ?
-                    (String) getMinecraftVersion.invoke(server) :
-                    serverClass.getPackage().getName().split("\\.")[3];
-        } catch (IllegalAccessException | InvocationTargetException e) {
-            throw new RuntimeException(e);
-        }
+        String[] split = Bukkit.getServer().getClass().getPackage().getName().split("\\.");
+        MC_VERSION = split.length >= 4 ? split[3] : "";
     }
 
     private ReflectionUtils() {}


### PR DESCRIPTION
1.20.6 paper no longer remaps CraftBukkit classes which caused the plugin to fail on load. So we check the length of the parsed package CraftBukkit server class name. We also do a try catch for getting CraftBukkit classes so we can get support relocated and non-relocated classes.

Tested with this script on 1.20.6 and 1.20.4
```python
import pyspigot as ps
from dev.magicmq.pyspigot.util import ReflectionUtils

def test_command(sender, label, args):
    sender.sendMessage('Hi!')
    craft_server = ReflectionUtils.getCraftBukkitClass("CraftServer")
    sender.sendMessage(str(craft_server))
    return True

registered_command = ps.command.registerCommand(test_command, 'test')
```
Results
1.20.6
![image](https://github.com/magicmq/pyspigot/assets/11567285/6395a60d-c47b-4171-9827-edeeede069d4)
1.20.4
![image](https://github.com/magicmq/pyspigot/assets/11567285/97824166-948d-4f3c-8e00-701967d0b51c)
