### PR TITLE
Use legacy bungeecord hover components

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.20.6-R0.1-SNAPSHOT</version>
+            <version>1.13-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/dev/magicmq/pyspigot/PluginListener.java
+++ b/src/main/java/dev/magicmq/pyspigot/PluginListener.java
@@ -18,8 +18,8 @@ package dev.magicmq.pyspigot;
 
 import dev.magicmq.pyspigot.config.PluginConfig;
 import dev.magicmq.pyspigot.util.StringUtils;
+import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.*;
-import net.md_5.bungee.api.chat.hover.content.Text;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -55,9 +55,9 @@ public class PluginListener implements Listener {
         pluginPage.setColor(net.md_5.bungee.api.ChatColor.RED);
         pluginPage.setUnderlined(true);
         pluginPage.setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, "https://spigotmc.org/resources/pyspigot.111006/"));
-        pluginPage.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(net.md_5.bungee.api.ChatColor.GOLD + "Click to go to the PySpigot plugin page")));
+        pluginPage.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, TextComponent.fromLegacyText(ChatColor.translateAlternateColorCodes('&', "&6Click to go to the PySpigot plugin page"))));
 
-        ComponentBuilder builder = new ComponentBuilder();
+        ComponentBuilder builder = new ComponentBuilder("");
         builder.append("You're running an outdated version of PySpigot. The latest version is " + version + ". ").color(net.md_5.bungee.api.ChatColor.RED).append(pluginPage);
         return builder.create();
     }

--- a/src/main/java/dev/magicmq/pyspigot/command/subcommands/HelpCommand.java
+++ b/src/main/java/dev/magicmq/pyspigot/command/subcommands/HelpCommand.java
@@ -21,7 +21,6 @@ import dev.magicmq.pyspigot.command.SubCommandMeta;
 import dev.magicmq.pyspigot.config.PluginConfig;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.*;
-import net.md_5.bungee.api.chat.hover.content.Text;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
@@ -48,27 +47,27 @@ public class HelpCommand implements SubCommand {
         documentation.setColor(ChatColor.AQUA);
         documentation.setUnderlined(true);
         documentation.setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, "https://pyspigot-docs.magicmq.dev"));
-        documentation.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(ChatColor.GOLD + "Click to go to the documentation for PySpigot")));
+        documentation.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, TextComponent.fromLegacyText(ChatColor.translateAlternateColorCodes('&', "&6Click to go to the documentation for PySpigot"))));
 
         TextComponent pluginPage = new TextComponent("Spigot Plugin Page");
         pluginPage.setColor(ChatColor.AQUA);
         pluginPage.setUnderlined(true);
         pluginPage.setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, "https://spigotmc.org/resources/pyspigot.111006/"));
-        pluginPage.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(ChatColor.GOLD + "Click to go to the PySpigot plugin page")));
+        pluginPage.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, TextComponent.fromLegacyText(ChatColor.translateAlternateColorCodes('&', "&6Click to go to the PySpigot plugin page"))));
 
         TextComponent discord = new TextComponent("PySpigot Discord");
         discord.setColor(ChatColor.AQUA);
         discord.setUnderlined(true);
         discord.setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, "https://discord.gg/f2u7nzRwuk"));
-        discord.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(ChatColor.GOLD + "Click to join the PySpigot Discord server")));
+        discord.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, TextComponent.fromLegacyText(ChatColor.translateAlternateColorCodes('&', "&6Click to join the PySpigot Discord server"))));
 
         TextComponent github = new TextComponent("PySpigot GitHub Repo");
         github.setColor(ChatColor.AQUA);
         github.setUnderlined(true);
         github.setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, "https://github.com/magicmq/pyspigot/issues"));
-        github.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(ChatColor.GOLD + "Click to go to the PySpigot GitHub Repo")));
+        github.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, TextComponent.fromLegacyText(ChatColor.translateAlternateColorCodes('&', "&6Click to go to the PySpigot GitHub Repo"))));
 
-        ComponentBuilder builder = new ComponentBuilder();
+        ComponentBuilder builder = new ComponentBuilder("");
         builder
                 .append("\n")
                 .appendLegacy(PluginConfig.getPrefix() + ChatColor.GREEN + "Some helpful links:").append("\n").reset()


### PR DESCRIPTION
Allows us to support 1.13 and up. On versions such as 1.16 the hover text component doesn't exist so instead we can just use legacy text.


https://github.com/user-attachments/assets/2dd01498-4236-4309-a5f9-fd6a38881d8c

