### PR TITLE
Patch threading to not join on Craft Scheduler Threads when script is unloaded

### DIFF
--- a/bukkit/src/main/java/dev/magicmq/pyspigot/bukkit/config/BukkitPluginConfig.java
+++ b/bukkit/src/main/java/dev/magicmq/pyspigot/bukkit/config/BukkitPluginConfig.java
@@ -138,6 +138,11 @@ public class BukkitPluginConfig implements PluginConfig {
     }
 
     @Override
+    public boolean patchThreading() {
+        return config.getBoolean("debug-options.patch-threading");
+    }
+
+    @Override
     public boolean loadJythonOnStartup() {
         return config.getBoolean("jython-options.init-on-startup");
     }

--- a/bungee/src/main/java/dev/magicmq/pyspigot/bungee/config/BungeePluginConfig.java
+++ b/bungee/src/main/java/dev/magicmq/pyspigot/bungee/config/BungeePluginConfig.java
@@ -138,6 +138,11 @@ public class BungeePluginConfig implements PluginConfig {
     }
 
     @Override
+    public boolean patchThreading() {
+        return config.getBoolean("debug-options.patch-threading");
+    }
+
+    @Override
     public String jythonLoggingLevel() {
         return config.getString("debug-options.jython-logging-level");
     }

--- a/core/src/main/java/dev/magicmq/pyspigot/config/PluginConfig.java
+++ b/core/src/main/java/dev/magicmq/pyspigot/config/PluginConfig.java
@@ -60,6 +60,8 @@ public interface PluginConfig {
 
     String jythonLoggingLevel();
 
+    boolean patchThreading();
+
     boolean loadJythonOnStartup();
 
     Properties getJythonProperties();

--- a/core/src/main/java/dev/magicmq/pyspigot/manager/script/ScriptManager.java
+++ b/core/src/main/java/dev/magicmq/pyspigot/manager/script/ScriptManager.java
@@ -744,6 +744,10 @@ public abstract class ScriptManager {
 
     private boolean stopScript(Script script, boolean error) {
         boolean gracefulStop = true;
+
+        if (PyCore.get().getConfig().patchThreading())
+            ScriptUtils.patchThreading(script.getInterpreter());
+
         if (!error) {
             PyObject stop = script.getInterpreter().get("stop");
             if (stop instanceof PyFunction stopFunction) {

--- a/core/src/main/java/dev/magicmq/pyspigot/util/ScriptUtils.java
+++ b/core/src/main/java/dev/magicmq/pyspigot/util/ScriptUtils.java
@@ -30,6 +30,7 @@ import org.python.core.PyString;
 import org.python.core.PySystemState;
 import org.python.core.StdoutWrapper;
 import org.python.core.ThreadState;
+import org.python.util.PythonInterpreter;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -44,6 +45,7 @@ public final class ScriptUtils {
 
     private static final StackWalker STACK_WALKER = StackWalker.getInstance();
     private static final Method EXCEPTION_TO_STRING;
+    private static final String THREADING_PATCH = "import threading_patch;threading_patch._patch();";
 
     static {
         try {
@@ -139,5 +141,15 @@ public final class ScriptUtils {
         threadState.exception = null;
 
         return exceptionString;
+    }
+
+    /**
+     * Patches the {@code _pickSomeNonDaemonThread} function in the threading module to avoid a server hang when a script uses the threading module in an asynchronous context.
+     * <p>
+     * For a complete description about why this is necessary, see <a href="https://github.com/magicmq/pyspigot/issues/18#issue-3012022678">this GitHub issue report</a>.
+     * @param interpreter The script's interpreter, used to execute code that applies the patch
+     */
+    public static void patchThreading(PythonInterpreter interpreter) {
+        interpreter.exec(THREADING_PATCH);
     }
 }

--- a/core/src/main/resources/Lib/threading_patch.py
+++ b/core/src/main/resources/Lib/threading_patch.py
@@ -1,0 +1,31 @@
+"""
+This module patches the _pickSomeNonDaemonThread function in the threading module. _pickSomeNonDaemonThread
+is called in the exit function of threading._MainThread to fetch all non-daemon threads seen by the threading
+module. The exit function blocks/waits for the thread to die (via thread.join()).
+
+The patch applies a condition that excludes returning any thread that is part of Bukkit's scheduler thread
+pool. These threads are identified by the name "Craft Scheduler Thread" and are kept alive for an arbitrary
+period of time. Thus, they should not be waited on to die with thread.join().
+
+PySpigot imports this module into all scripts just prior to script unload, if "debug-options.patch-threading"
+is "true" in the PySpigot config.yml. The patch is only applied if the script imported threading at an earlier
+point in time (I.E. sys.modules contains "threading").
+
+For more information, see https://github.com/magicmq/pyspigot/issues/18#issue-3012022678
+"""
+import sys
+
+
+def _patch():
+    """patches the _pickSomeNonDaemonThread function in the threading module."""
+    if "threading" in sys.modules:
+        import threading
+
+        def _pickSomeNonDaemonThreadPatched():
+            for t in threading.enumerate():
+                # In addition to excluding daemon threads and dead threads, exclude Craft Scheduler Threads
+                if not t.isDaemon() and t.isAlive() and "Craft Scheduler Thread" not in t.getName():
+                    return t
+            return None
+
+        threading._pickSomeNonDaemonThread = _pickSomeNonDaemonThreadPatched

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -46,3 +46,5 @@ debug-options:
   show-update-messages: true
   # The logging level for Jython internals. Can be useful to set this to FINE or ALL for debugging purposes. Note: the server's root logger will also need to be configured to accept debug messages for Jython's debug messages to show.
   jython-logging-level: 'INFO'
+  # If true, PySpigot will patch the threading module on script unload (if it's being used in the script) in order to prevent the server from hanging. For more information, see https://github.com/magicmq/pyspigot/issues/18#issue-3012022678
+  patch-threading: true


### PR DESCRIPTION
## Additions, Changes, and Deletions

### Addition of patch to threading module, applied on script unload

Adds a Python module that patches the `_pickSomeNonDaemonThread` function in the `threading` module. `_pickSomeNonDaemonThread` is called in the exit function of `threading._MainThread` to fetch all non-daemon threads seen by the `threading` module. The exit function blocks/waits for the thread to die (via `thread.join()`), which is problematic for Bukkit scheduler threads.

The patch applies a condition that excludes returning any thread that is part of Bukkit's scheduler thread pool. These threads are identified by the name "Craft Scheduler Thread" and are kept alive for an arbitrary period of time. Thus, they should not be waited on to die with `thread.join()`.

### Addition of config value

Adds a config option, `debug-options.patch-threading`, which controls whether the threading module is patched on script unload.

## Fixes

Fixes #18 