### PR TITLE
Update teleport.py

### DIFF
--- a/examples/teleport/teleport.py
+++ b/examples/teleport/teleport.py
@@ -91,7 +91,7 @@ inventory = create_inventory(inventory_size, inventory_title, items)
 
 def on_inventory_click(event):
     if event.getClickedInventory() is not None:
-        if event.getClickedInventory().getTitle() == inventory.getTitle():
+        if event.getView().getTitle() == inventory_title:
             event.setCancelled(True)
 
             item = event.getCurrentItem()
@@ -125,5 +125,5 @@ ps.command_manager().registerCommand(on_command, 'teleportgui', 'Open the telepo
 def stop():
     for player in Bukkit.getOnlinePlayers():
         if player.getOpenInventory() is not None:
-            if player.getOpenInventory().getTitle() == inventory.getTitle():
+            if player.getOpenInventory().getTitle() == inventory_title:
                 player.closeInventory()


### PR DESCRIPTION
getView to get inventory_click Title


- [ x] 🐞 Bug fix
- [ ] 👌 Enhancement (improve something existing)
- [ ] ✨ New functionality
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 Description
Minecraft has changed some functionnalities at a moment, and on inventory_click event, the getTitle() does not work anymore, to check if the inventory is the one concerned by the teleport plugin. It needed a little fix.
As a possible performance gain I replaced 2 others getTitle() for using a variable instead, as I guess its less work for the server. 

Thank you.